### PR TITLE
fix: support Assert.Equivalent for RomanNumeral via IConvertible

### DIFF
--- a/05.roman-numerals/Ktt.RomanNumerals.Test/VariousTests.cs
+++ b/05.roman-numerals/Ktt.RomanNumerals.Test/VariousTests.cs
@@ -19,9 +19,9 @@ public class VariousTests
         RomanNumeral IV = "IV";
 
         int a = IV - 1;
-        var b = 4 - I;
+        int b = 4 - I;
         int c = IV - "I";
-        int d = (RomanNumeral)"IV" - I;
+        int d = "IV" - I;
         int e = IV - I;
 
         Assert.Equivalent(3, a);
@@ -31,9 +31,9 @@ public class VariousTests
         Assert.Equivalent(3, e);
 
         string f = IV - 1;
-        string g = (RomanNumeral)4 - I;
+        string g = 4 - I;
         string h = IV - "I";
-        var i = "IV" - I;
+        string i = "IV" - I;
         string j = IV - I;
 
         Assert.Equivalent("III", f);
@@ -42,16 +42,16 @@ public class VariousTests
         Assert.Equivalent("III", i);
         Assert.Equivalent("III", j);
 
-        var k = IV - 1;
+        RomanNumeral k = IV - 1;
         RomanNumeral l = 4 - I;
-        var m = IV - "I";
+        RomanNumeral m = IV - "I";
         RomanNumeral n = "IV" - I;
-        var o = IV - I;
+        RomanNumeral o = IV - I;
 
-        Assert.Equivalent("III", k.ToString());
-        Assert.Equivalent("III", l.ToString());
-        Assert.Equivalent("III", m.ToString());
-        Assert.Equivalent("III", n.ToString());
-        Assert.Equivalent("III", o.ToString());
+        Assert.Equivalent(3, k);
+        Assert.Equivalent(3, l);
+        Assert.Equivalent(3, m);
+        Assert.Equivalent(3, n);
+        Assert.Equivalent(3, o);
     }
 }

--- a/05.roman-numerals/Ktt.RomanNumerals/RomanNumeral.CompareOperators.cs
+++ b/05.roman-numerals/Ktt.RomanNumerals/RomanNumeral.CompareOperators.cs
@@ -12,6 +12,26 @@ public partial class RomanNumeral
         return Compare(r1, r2) != 0;
     }
 
+    public static bool operator ==(RomanNumeral r1, string r2)
+    {
+        return r1.Number == Parse(r2).Number;
+    }
+
+    public static bool operator !=(RomanNumeral r1, string r2)
+    {
+        return !(r1 == r2);
+    }
+
+    public static bool operator ==(string r1, RomanNumeral r2)
+    {
+        return r2 == r1;
+    }
+
+    public static bool operator !=(string r1, RomanNumeral r2)
+    {
+        return !(r1 == r2);
+    }
+
     public static bool operator <(RomanNumeral r1, RomanNumeral r2)
     {
         return (Compare(r1, r2) < 0);

--- a/05.roman-numerals/Ktt.RomanNumerals/RomanNumeral.Equals.cs
+++ b/05.roman-numerals/Ktt.RomanNumerals/RomanNumeral.Equals.cs
@@ -1,10 +1,54 @@
 ﻿namespace Ktt.RomanNumerals;
 
-public partial class RomanNumeral : IComparable, IComparable<RomanNumeral>
+public partial class RomanNumeral : IComparable, IComparable<RomanNumeral>, IEquatable<int>, IEquatable<string>
 {
+    public bool Equals(int other)
+    {
+        return Number == other;
+    }
+
+    public bool Equals(string? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return Number == Parse(other).Number;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     public override bool Equals(object? obj)
     {
-        return CompareTo(obj) == 0;
+        if (obj is int i)
+        {
+            return Number == i;
+        }
+
+        if (obj is string s)
+        {
+            try
+            {
+                return Number == Parse(s).Number;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        if (obj is RomanNumeral rn)
+        {
+            return Number == rn.Number;
+        }
+
+        return false;
     }
 
     public override int GetHashCode()

--- a/05.roman-numerals/Ktt.RomanNumerals/RomanNumeral.IConvertible.cs
+++ b/05.roman-numerals/Ktt.RomanNumerals/RomanNumeral.IConvertible.cs
@@ -1,0 +1,48 @@
+using System.Globalization;
+
+namespace Ktt.RomanNumerals;
+
+public partial class RomanNumeral : IConvertible
+{
+    TypeCode IConvertible.GetTypeCode() => TypeCode.Int32;
+
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => Convert.ToBoolean(Number, provider);
+
+    byte IConvertible.ToByte(IFormatProvider? provider) => Convert.ToByte(Number, provider);
+
+    char IConvertible.ToChar(IFormatProvider? provider) => Convert.ToChar(Number, provider);
+
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => Convert.ToDateTime(Number, provider);
+
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => Number;
+
+    double IConvertible.ToDouble(IFormatProvider? provider) => Number;
+
+    short IConvertible.ToInt16(IFormatProvider? provider) => Convert.ToInt16(Number, provider);
+
+    int IConvertible.ToInt32(IFormatProvider? provider) => Number;
+
+    long IConvertible.ToInt64(IFormatProvider? provider) => Number;
+
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => Convert.ToSByte(Number, provider);
+
+    float IConvertible.ToSingle(IFormatProvider? provider) => Number;
+
+    string IConvertible.ToString(IFormatProvider? provider) => ToString();
+
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider)
+    {
+        if (conversionType == typeof(RomanNumeral))
+        {
+            return this;
+        }
+
+        return Convert.ChangeType(Number, conversionType, provider ?? CultureInfo.CurrentCulture);
+    }
+
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => Convert.ToUInt16(Number, provider);
+
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => Convert.ToUInt32(Number, provider);
+
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => Convert.ToUInt64(Number, provider);
+}

--- a/05.roman-numerals/Ktt.RomanNumerals/RomanNumeral.MathOperators.cs
+++ b/05.roman-numerals/Ktt.RomanNumerals/RomanNumeral.MathOperators.cs
@@ -2,15 +2,14 @@
 
 public partial class RomanNumeral
 {
-    public static int operator +(int r1, RomanNumeral r2)
+    public static RomanNumeral operator +(int r1, RomanNumeral r2)
     {
-        return r1 + r2.Number;
+        return new RomanNumeral(r1) + r2;
     }
 
-    public static string operator +(string r1, RomanNumeral r2)
+    public static RomanNumeral operator +(string r1, RomanNumeral r2)
     {
-        var r = Parse(r1) + r2;
-        return r.ToString();
+        return Parse(r1) + r2;
     }
 
     public static RomanNumeral operator +(RomanNumeral r1, string r2)
@@ -30,16 +29,14 @@ public partial class RomanNumeral
         return new RomanNumeral(n);
     }
 
-    public static int operator -(int r1, RomanNumeral r2)
+    public static RomanNumeral operator -(int r1, RomanNumeral r2)
     {
-        var r = new RomanNumeral(r1) - r2;
-        return r.Number;
+        return new RomanNumeral(r1) - r2;
     }
 
-    public static string operator -(string r1, RomanNumeral r2)
+    public static RomanNumeral operator -(string r1, RomanNumeral r2)
     {
-        var r = Parse(r1) - r2;
-        return r.ToString();
+        return Parse(r1) - r2;
     }
 
     // Negative results default to 0 (NULLA) — Romans had no concept of negative numbers


### PR DESCRIPTION
- Return RomanNumeral from int/string math operators so implicit conversion keeps the RN type for Assert.Equivalent comparisons
- Add ==/!= operators for RomanNumeral-string comparisons
- Implement IEquatable<int>/IEquatable<string> with Equals override
- Implement IConvertible on RomanNumeral so Convert.ChangeType works in xUnit VerifyEquivalenceIntrinsics
- Clean up test: explicit types, Assert.Equivalent(3, k) instead of k.ToString()